### PR TITLE
Support PEP517 builds when appropriate

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,7 +65,7 @@ $PYTHON /validate_version.py $REF
 
 printf "Prepare for publication...\n\n"
 $GIT clean -fxd
-retval = 1
+retval=1
 if [[ -e pyproject.toml ]]; then
     grep "build-backend" pyproject.toml
     retval=$?

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,6 +65,7 @@ $PYTHON /validate_version.py $REF
 
 printf "Prepare for publication...\n\n"
 $GIT clean -fxd
+retval = 1
 if [[ -e pyproject.toml ]]; then
     grep "build-backend" pyproject.toml
     retval=$?


### PR DESCRIPTION
Check for the presence of a pyproject.toml file. If that file contains a `build-backend` value, use `pep517.build --source` to build the package for publication, otherwise use `setup.py build sdist`.