### PR TITLE
Add custom steps to allow building wheels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Automatic publication of Python packages to PyPI
 
-This repository defines a Github action to provide opt-in automatic publication of Python packages to PyPI upon qualifying Github release events.
+This repository defines a Github action to provide opt-in automatic publication of Python packages to PyPI upon qualifying Github release events. It also defines separate custom Github action steps for building Python wheels and source distributions, validating repository metadata, and publishing to PyPI.
 This repository does not need to be cloned or interacted with in order to take advantage of the service.
 See below for documentation.
 
@@ -40,10 +40,18 @@ The default set of credentials used to publish packages to PyPI are those of the
 
    1) Open the **Settings** page of the repository (top portion of the page, on the line under the repository name).
    2) Select **Secrets** from the list on the left hand side.
-   3) Define a secret with the name `PYPI_USERNAME_OVERRIDE` the value of which is the PyPI username to be used.
-   4) Define another secret with the name `PYPI_PASSWORD_OVERRIDE` the value of which is the PyPI password to be used.
+   3) Define a secret with the name `PYPI_USERNAME_STSCI_MAINTAINER` the value of which is the PyPI username to be used.
+   4) Define another secret with the name `PYPI_PASSWORD_STSCI_MAINTAINER` the value of which is the PyPI password to be used.
    
 Whenever a new release is made, the package will be created and published to PyPI using the supplied credentials.
+
+### Testing the workflow
+
+By default, the workflow will publish to the production PyPI repository. For testing purposes, it can be configured to publish to the test PyPI repository at https://test.pypi.org by creating a secret called `PYPI_TEST`:
+
+   1) Open the **Settings** page of the repository (top portion of the page, on the line under the repository name).
+   2) Select **Secrets** from the list on the left hand side.
+   3) Define a secret with the name `PYPI_TEST` the value of which is 'true'.
 
 ## Problems
 

--- a/build-sdist/action.yml
+++ b/build-sdist/action.yml
@@ -1,0 +1,23 @@
+name: 'Build source distribution'
+description: 'Build a Python source distribution using build and upload the resulting artifact'
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+      name: Install Python
+      with:
+        python-version: '3.8'
+
+    - name: Install build tools
+      shell: 'bash'
+      run: python -m pip install build
+
+    - name: Build sdist
+      shell: 'bash'
+      run: python -m build --sdist
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: dist/*.tar.gz

--- a/build-sdist/action.yml
+++ b/build-sdist/action.yml
@@ -4,6 +4,8 @@ runs:
   using: 'composite'
   steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - uses: actions/setup-python@v2
       name: Install Python
@@ -16,7 +18,8 @@ runs:
 
     - name: Build sdist
       shell: 'bash'
-      run: python -m build --sdist
+      run: python -m build --sdist .
+
 
     - uses: actions/upload-artifact@v2
       with:

--- a/build-wheel/action.yml
+++ b/build-wheel/action.yml
@@ -4,6 +4,8 @@ runs:
   using: 'composite'
   steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - uses: actions/setup-python@v2
       name: Install Python

--- a/build-wheel/action.yml
+++ b/build-wheel/action.yml
@@ -1,0 +1,33 @@
+name: 'Build wheel'
+description: 'Build a Python wheel using cibuildwheel and upload the resulting artifact'
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+      name: Install Python
+      with:
+        python-version: '3.8'
+
+    - name: Configure Numpy builds on macos if necessary
+      shell: 'bash'
+      run: |
+        python3 -m pip install build
+        echo "
+        import os
+        import build
+        requires = build.ProjectBuilder('.').build_system_requires
+        if 'numpy' in requires or 'oldest-supported-numpy' in requires:
+          # see https://numpy.org/doc/stable/user/building.html#lapack
+          print('CIBW_ENVIRONMENT_MACOS=BLAS=None LAPACK=None ATLAS=None ' + os.getenv('CIBW_ENVIRONMENT_MACOS', ''))
+          # pypy builds seem to ignore the above environment variables, so we just won't build pypy wheels for now
+          print('CIBW_SKIP=pp37-macosx_x86_64 ' + os.getenv('CIBW_SKIP', ''))
+        " | python3 >> $GITHUB_ENV
+
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.1.1
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: ./wheelhouse/*.whl

--- a/publish/action.yml
+++ b/publish/action.yml
@@ -1,0 +1,55 @@
+name: 'Publish to PyPI'
+description: 'Publishes an artifact to PyPI'
+inputs:
+  user:
+    description: 'The username to use to publish to PyPI. Defaults to `__token__`.'
+    required: false
+    default: '__token__'
+  password:
+    description: 'The password to use to publish to PyPI'
+    required: true
+  repository_url:
+    description: 'The PyPI repository URL to publish to'
+    required: false
+  test_user:
+    description: 'The username to use when test is set to true. Uses the value of `user` if not provided.'
+    required: false
+  test_password:
+    description: 'The password to use when test is set to true. Uses the value of `password` if not provided.'
+    required: false
+  test_repository_url:
+    description: 'The PyPI repository URL to publish to when test is set to true. Defaults to `https://test.pypi.org/legacy/`'
+    required: false
+    default: 'https://test.pypi.org/legacy/'
+  test:
+    description: 'Whether to publish to the test repository or the production repository'
+    required: false
+    default: false
+  verify_metadata:
+    description: 'Whether to check package metadata before uploading'
+    required: false
+    default: true
+  skip_existing:
+    description: 'Do not fail if a Python package distribution exists in the target package index'
+    required: false
+    default: false
+  verbose:
+    description: 'Show verbose output.'
+    required: false
+    default: false
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: artifact
+        path: dist
+
+    - uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        user: ${{ (inputs.test && (inputs.test_user || inputs.user)) || inputs.user }}
+        password: ${{ (inputs.test && (inputs.test_password || inputs.password)) || inputs.password }}
+        repository_url: ${{ (inputs.test && inputs.test_repository_url) || inputs.repository_url }}
+        verify_metadata: ${{ inputs.verify_metadata }}
+        skip_existing: ${{ inputs.skip_existing }}
+        verbose: ${{ inputs.verbose }}

--- a/validate/action.yml
+++ b/validate/action.yml
@@ -1,0 +1,25 @@
+name: 'Validate metadata'
+description: 'Validates tagged package version is a valid semver value'
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/setup-python@v2
+      name: Install Python
+      with:
+        python-version: '3.8'
+
+    - name: Validate tag
+      shell: 'bash'
+      run: |
+        python -m pip install semver
+        echo "
+        import os
+        import semver
+
+        gitref = os.environ['GITHUB_REF']
+        print(f'\nVersion validation argument: {gitref}')
+        tag = gitref.split('/')[-1]
+        print(f'Tag: {tag}')
+        version = semver.VersionInfo.parse(tag)
+        print('Tag is a valid semver value.')
+        " | python


### PR DESCRIPTION
This change adds 4 new custom steps:
* `validate` runs the semver validation script
* `build-sdist` builds a source distribution of the current repository and uploads it as an artifact of the current build
* `build-wheel` builds a wheel of the current repository and uploads it as an artifact of the current build
* `publish` downloads the previously built artifacts and then publishes them to PyPI

These new steps are necessary because we would like to enable users of the workflow to also build and publish wheels in addition to source distributions. Building platform wheels requires the build to run on the target operating system, and due to limitations in GitHub Actions, the operating system to run a step on can only be specified from the workflow `.yml`, not from within a `composite` custom action. While we could have combined all four of these steps into one for better simplicity and maintainability, this step would still have to be run once on each target platform, meaning that the validation, source distribution, and publishing steps would run multiple times per build, which is less than ideal.

This change will be accompanied later by a new version of the [`publish-to-pypi.yml`](https://github.com/spacetelescope/.github/blob/master/workflow-templates/publish-to-pypi.yml) template, which uses them in favor of the current custom action.

Known issues:
* `build-wheel` errors out if the repository does not require a platform wheel (i.e. contains no C extensions)