### PR TITLE
Add reusable GitHub Workflow

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,9 +2,16 @@ name: Publish to PyPI
 
 on:
   workflow_call:
-    secrets:
+    inputs:
       test:
         required: false
+        default: false
+        type: boolean
+      build_platform_wheels:
+        required: false
+        default: false
+        type: boolean
+    secrets:
       user:
         required: true
       password:
@@ -21,6 +28,7 @@ jobs:
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
+    if: ${{ inputs.build_platform_wheels }}
     needs: [validate]
     runs-on: ${{ matrix.os }}
     strategy:
@@ -30,6 +38,31 @@ jobs:
     steps:
       - uses: spacetelescope/action-publish_to_pypi/build-wheel@master
 
+  build_wheel:
+    name: Build wheel
+    if: ${{ !inputs.build_platform_wheels }}
+    needs: [validate]
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.8'
+
+      - name: Install build tools
+        run: python -m pip install build
+
+      - name: Build wheel
+        run: python -m build --wheel .
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.whl
+
   build_sdist:
     name: Build source distribution
     needs: [validate]
@@ -37,13 +70,26 @@ jobs:
     steps:
       - uses: spacetelescope/action-publish_to_pypi/build-sdist@master
 
-  upload_pypi:
+  upload_pypi_platform_wheels:
+    if: ${{ inputs.build_platform_wheels }}
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     steps:
       - uses: spacetelescope/action-publish_to_pypi/publish@master
         with:
-          test: ${{ secrets.test }}
+          test: ${{ inputs.test }}
+          user: ${{ secrets.user }}
+          password: ${{ secrets.password }}
+          test_password: ${{ secrets.test_password }}
+
+  upload_pypi:
+    if: ${{ !inputs.build_platform_wheels }}
+    needs: [build_wheel, build_sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: spacetelescope/action-publish_to_pypi/publish@master
+        with:
+          test: ${{ inputs.test }}
           user: ${{ secrets.user }}
           password: ${{ secrets.password }}
           test_password: ${{ secrets.test_password }}


### PR DESCRIPTION
GitHub very recently introduced [reusable workflows](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows), which solves several of our problems surrounding maintainability.

This will allow us to greatly simplify the code that developers need to pull into their repositories to publish to PyPI, and make it easier for them to configure themselves if they wish.

This reusable workflow also adds support for an optional `build_platform_wheels` property, allowing repositories that do not contain C extensions to use it.