### PR TITLE
Fix bug in publish/action.yml where passing test: false would still publish to test_repository_url

### DIFF
--- a/publish/action.yml
+++ b/publish/action.yml
@@ -47,9 +47,9 @@ runs:
 
     - uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
-        user: ${{ (inputs.test && (inputs.test_user || inputs.user)) || inputs.user }}
-        password: ${{ (inputs.test && (inputs.test_password || inputs.password)) || inputs.password }}
-        repository_url: ${{ (inputs.test && inputs.test_repository_url) || inputs.repository_url }}
+        user: ${{ (inputs.test == 'true' && inputs.test_user) || inputs.user }}
+        password: ${{ (inputs.test == 'true' && inputs.test_password) || inputs.password }}
+        repository_url: ${{ (inputs.test == 'true' && inputs.test_repository_url) || inputs.repository_url }}
         verify_metadata: ${{ inputs.verify_metadata }}
         skip_existing: ${{ inputs.skip_existing }}
         verbose: ${{ inputs.verbose }}


### PR DESCRIPTION
This seems to have been caused by GitHub Actions passing all inputs as strings, meaning that when `test: false` was passed, the custom action received the string `'false'` rather than a boolean `false`. GitHub Actions treats nonempty strings as truthy in boolean expressions, making it impossible to publish to the non-test repository.