### PR TITLE
Bump Python version from 3.8 to 3.9 for build-sdist and build-wheel steps

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Install build tools
         run: python -m pip install build

--- a/build-sdist/action.yml
+++ b/build-sdist/action.yml
@@ -10,7 +10,7 @@ runs:
     - uses: actions/setup-python@v2
       name: Install Python
       with:
-        python-version: '3.8'
+        python-version: '3.9'
 
     - name: Install build tools
       shell: 'bash'

--- a/build-wheel/action.yml
+++ b/build-wheel/action.yml
@@ -10,7 +10,7 @@ runs:
     - uses: actions/setup-python@v2
       name: Install Python
       with:
-        python-version: '3.8'
+        python-version: '3.9'
 
     - name: Configure Numpy builds on macos if necessary
       shell: 'bash'


### PR DESCRIPTION
This fixes https://jira.stsci.edu/browse/SPB-920.

Tested by building Drizzlepac 3.4.1 here: https://github.com/zanecodes/drizzlepac/actions/runs/2103664297