### PR TITLE
Fix semver validation to permit leading v on git tags

### DIFF
--- a/validate/action.yml
+++ b/validate/action.yml
@@ -20,6 +20,6 @@ runs:
         print(f'\nVersion validation argument: {gitref}')
         tag = gitref.split('/')[-1]
         print(f'Tag: {tag}')
-        version = semver.VersionInfo.parse(tag)
+        version = semver.VersionInfo.parse(tag.lstrip('v'))
         print('Tag is a valid semver value.')
         " | python


### PR DESCRIPTION
Many of the repositories that use `action-publish_to_pypi` use git tags of the form `v1.0.0` rather than simply `1.0.0`, causing them to fail the version validation step.

The legacy version of `action-publish_to_pypi` does not check the exit code of the version validation script, and simply outputs an error and moves on if validation fails.

The new version, the reusable workflow, will fail the entire run if validation fails. Rather than changing it to ignore the validation failure, I've opted to loosen it to allow `v1.0.0` style tags by stripping the leading `v` before validating.

Since version validation was effectively disabled completely in the old action, we may also want to add an optional `validate_version` input to the reusable workflow, to permit teams to use any tagging scheme they want. I'm not sure whether to default it to `false` to go back to matching the old action's behavior, or `true` to maintain the new action's existing behavior.

Tested against the [`pysiaf`](https://github.com/spacetelescope/pysiaf) repository here: https://github.com/zanecodes/pysiaf/actions/runs/2314790714